### PR TITLE
Slow down a little when getting items from the HackerNews API

### DIFF
--- a/ChanheLog.md
+++ b/ChanheLog.md
@@ -1,0 +1,20 @@
+# OSHit ChangeLog
+
+## v0.1.1
+
+**Released: 2023-01-01**
+
+- Made the gathering of items from the API less greedy, limiting the number
+  of concurrent connections (yes, 500+ connections all at once is kind of a
+  bad idea who knew?). Default limit is 50.
+- Added a configuration option to the configuration file for the above.
+- Added a connection timeout setting to the configuration file; hopefully
+  useful for folk who are on slower connections.
+
+## v0.1.0
+
+**Released: 2023-01-01**
+
+- Initial release.
+
+[//]: # (ChanheLog.md ends here)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ that will let you view and navigate its comments.
 
 ![Viewing comments](https://raw.githubusercontent.com/davep/oshit/main/images/oshit-comments.png)
 
+## Tweaking
+
+Because of the nature of the HackerNews API there might be a need for you to
+dial in the ideal number of concurrent connections made to load up the data,
+and also the timeout for the connections. As of the time of writing the
+defaults are 50 concurrent connections and a timeout of 20 seconds.
+
+If you run into problems look in `~/.config/oshit/configuration.json` and
+change the `"maximum_concurrency"` and `"connection_timeout"` values to
+taste.
+
 ## Getting help
 
 If you need help, or have any ideas, please feel free to [raise an
@@ -52,7 +63,8 @@ discussion](https://github.com/davep/oshit/discussions).
 
 Things I'm considering adding or addressing:
 
-- [ ] Chill out on item loading (see [#2](https://github.com/davep/oshit/issues/2))
+- [X] Chill out on item loading (see [#2](https://github.com/davep/oshit/issues/2))
+- [ ] Add a configuration dialog for the connection value tweaks.
 - [ ] Some degree of caching of items to reduce API hits.
 - [ ] Expand the text-cleaning code to handle links, etc.
 - [ ] Look at some "markup" of comments, eg: make quoted text more obvious.

--- a/oshit/__init__.py
+++ b/oshit/__init__.py
@@ -3,11 +3,11 @@
 ######################################################################
 # Main app information.
 __author__ = "Dave Pearson"
-__copyright__ = "Copyright 2023, Dave Pearson"
+__copyright__ = "Copyright 2024, Dave Pearson"
 __credits__ = ["Dave Pearson"]
 __maintainer__ = "Dave Pearson"
 __email__ = "davep@davep.org"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __licence__ = "GPLv3+"
 
 ##############################################################################

--- a/oshit/app/data/config.py
+++ b/oshit/app/data/config.py
@@ -26,8 +26,8 @@ class Configuration:
     maximum_concurrency: int = 50
     """The maximum number of connections to use when getting items."""
 
-    connection_timeout: int | None = 5
-    """The timeout to use when connecting to the HackerNews API."""
+    connection_timeout: int | None = 20
+    """The timeout (in seconds) to use when connecting to the HackerNews API."""
 
 
 ##############################################################################

--- a/oshit/app/data/config.py
+++ b/oshit/app/data/config.py
@@ -23,6 +23,12 @@ class Configuration:
     compact_mode: bool = True
     """Should the items display in compact mode?"""
 
+    maximum_concurrency: int = 50
+    """The maximum number of connections to use when getting items."""
+
+    connection_timeout: int | None = 5
+    """The timeout to use when connecting to the HackerNews API."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/oshit/app/screens/main.py
+++ b/oshit/app/screens/main.py
@@ -12,6 +12,7 @@ from textual.widgets import Footer, Header
 # Local imports.
 from ... import __version__
 from ...hn import HN
+from ..data.config import load_configuration
 from ..commands import ShowComments, ShowUser
 from ..widgets import HackerNews, Items
 from .comments import Comments
@@ -65,7 +66,11 @@ class Main(Screen[None]):
     def __init__(self) -> None:
         """Initialise the screen."""
         super().__init__()
-        self._hn = HN()
+        config = load_configuration()
+        self._hn = HN(
+            max_concurrency=config.maximum_concurrency,
+            timeout=config.connection_timeout,
+        )
         """The HackerNews client object."""
 
     def compose(self) -> ComposeResult:

--- a/oshit/hn/client.py
+++ b/oshit/hn/client.py
@@ -36,14 +36,16 @@ class HN:
     class NoSuchUser(Error):
         """Exception raised if no such user exists."""
 
-    def __init__(self, max_concurrency: int = 50) -> None:
+    def __init__(self, max_concurrency: int = 50, timeout: int | None = 5) -> None:
         """Initialise the API client object.
 
         Args:
             max_concurrency: The maximum number of concurrent connections to use.
+            timeout: The timeout for an attempted connection.
         """
         self._client_: AsyncClient | None = None
         self._max_concurrency = max_concurrency
+        self._timeout = timeout
 
     @property
     def _client(self) -> AsyncClient:
@@ -78,6 +80,7 @@ class HN:
                 self._api_url(*path),
                 params=params,
                 headers={"user-agent": self.AGENT},
+                timeout=self._timeout,
             )
         except RequestError as error:
             raise self.RequestError(str(error))

--- a/oshit/hn/client.py
+++ b/oshit/hn/client.py
@@ -44,8 +44,11 @@ class HN:
             timeout: The timeout for an attempted connection.
         """
         self._client_: AsyncClient | None = None
+        """The HTTPX client."""
         self._max_concurrency = max_concurrency
+        """The maximum number of concurrent connections to use."""
         self._timeout = timeout
+        """The timeout to use on connections."""
 
     @property
     def _client(self) -> AsyncClient:

--- a/oshit/hn/client.py
+++ b/oshit/hn/client.py
@@ -37,7 +37,11 @@ class HN:
         """Exception raised if no such user exists."""
 
     def __init__(self, max_concurrency: int = 50) -> None:
-        """Initialise the API client object."""
+        """Initialise the API client object.
+
+        Args:
+            max_concurrency: The maximum number of concurrent connections to use.
+        """
         self._client_: AsyncClient | None = None
         self._max_concurrency = max_concurrency
 


### PR DESCRIPTION
The HackerNews API is... fun. There's no way of saying "get me the data for all of these stories please", all you can do is get one at a time. I'd initially done this concurrently which was pretty bloody fast, but also meant that when it came to things like "Top" or "New", you were making at least 500 concurrent HTTP requests.

Yes, I agree, in 2024 this should not be a problem and we should be allow to spam API endpoints with no consequence. Apparently we're not there yet.

So, in an effort to behave better[^1], this PR adds a configurable limit on the number of concurrent connections, and also adds a higher and configurable timeout on the connections too.

Super huge thanks to @mihaitodor for being one of those awesome folk who runs into a problem, comments about it on HackerNews, *and* then goes and lets the developer know by filing an issue. That's some faith-in-humanity-restored-level-shit right there.

I guess there's hope for 2024 yet!

All of which is to verbosely say... I think this helps fix #2 for now (although a more lazy method of loading things into the UI might be something for me to switch to longer-term).

[^1]: In other words, do the thing I should have done to start with, if I wasn't paying way more attention to the UI rather than *actually* doing some proper coding on the tricky bits.