### PR TITLE
Add a quick method of visiting URLs within comments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # OSHit ChangeLog
 
+## 0.3.0
+
+**Released: WiP**
+
+- Added a quick way of visiting links within comments.
+
 ## v0.2.0
 
 **Released: 2023-01-07**

--- a/oshit/app/screens/links.py
+++ b/oshit/app/screens/links.py
@@ -1,0 +1,78 @@
+"""Provides a dialog for viewing and visiting links."""
+
+##############################################################################
+# Python imports.
+from webbrowser import open as open_url
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, OptionList
+
+
+##############################################################################
+class Links(ModalScreen):
+    """Modal dialog for showing and visiting links."""
+
+    DEFAULT_CSS = """
+    Links {
+        align: center middle;
+
+        Vertical {
+            padding: 1 2;
+            height: auto;
+            width: auto;
+            max-width: 50%;
+            background: $surface;
+            border: panel $primary;
+            border-title-color: $accent;
+        }
+
+        Horizontal {
+            height: auto;
+            width: 100%;
+            align-horizontal: right;
+            border-top: solid $primary;
+            padding-top: 1;
+
+            Button {
+                margin-left: 1;
+            }
+        }
+    }
+    """
+
+    BINDINGS = [("escape", "close")]
+
+    def __init__(self, links: list[str]) -> None:
+        """Initialise the links dialog.
+
+        Args:
+            links: The links to show the user.
+        """
+        super().__init__()
+        self._links = links
+
+    def compose(self) -> ComposeResult:
+        """Compose the conent of the dialog."""
+        with Vertical() as dialog:
+            dialog.border_title = "Available links"
+            yield OptionList(*self._links)
+            with Horizontal():
+                yield Button("Okay [dim]\\[Esc][/]", id="close")
+
+    @on(OptionList.OptionSelected)
+    def visit(self, event: OptionList.OptionSelected):
+        """Visit the selected link."""
+        open_url(self._links[event.option_index])
+
+    @on(Button.Pressed, "#close")
+    def action_close(self) -> None:
+        """Close the dialog screen."""
+        self.dismiss()
+
+
+### links.py ends here

--- a/oshit/app/widgets/comment_card.py
+++ b/oshit/app/widgets/comment_card.py
@@ -25,6 +25,7 @@ from humanize import naturaltime
 # Local imports.
 from ...hn import HN
 from ...hn.item import Article, Comment
+from ..screens.links import Links
 from ..screens.user import UserDetails
 
 
@@ -100,6 +101,7 @@ class CommentCard(Vertical, can_focus=True):
 
     BINDINGS = [
         Binding("enter", "gndn"),
+        Binding("l", "links", "Links"),
         Binding("s", "next(1)", "Next Sibling"),
         Binding("S", "next(-1)", "Prev Sibling", key_display="Sh+S"),
         Binding("p", "goto_parent", "Parent"),
@@ -140,6 +142,16 @@ class CommentCard(Vertical, can_focus=True):
         yield Label(
             f"{self.comment.by}, {naturaltime(self.comment.time)}", classes="byline"
         )
+
+    def action_links(self) -> None:
+        """Show the links in the comment to the user."""
+        links = self.comment.urls
+        if not links:
+            self.notify("No links found in the comment")
+        elif len(links) == 1:
+            open_url(links[0])
+        else:
+            self.app.push_screen(Links(self.comment.urls))
 
     def action_view_online(self) -> None:
         """View the comment on HackerNews."""

--- a/oshit/hn/item/comment.py
+++ b/oshit/hn/item/comment.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 ##############################################################################
 # Local imports.
-from ..text import tidy_text
+from ..text import tidy_text, text_urls
 from .base import Item
 from .loader import Loader
 
@@ -40,6 +40,11 @@ class Comment(Item):
     def text(self) -> str:
         """The text for the comment."""
         return tidy_text(self.raw_text)
+
+    @property
+    def urls(self) -> list[str]:
+        """The URLs in the comment."""
+        return text_urls(self.raw_text)
 
     @property
     def flagged(self) -> bool:

--- a/oshit/hn/text.py
+++ b/oshit/hn/text.py
@@ -2,8 +2,10 @@
 
 ##############################################################################
 # Python imports.
-from re import sub
 from html import unescape
+from re import compile, sub
+from typing import Pattern
+from typing_extensions import Final
 
 ##############################################################################
 # TODO! Throw in some proper HTML parsing here.
@@ -21,6 +23,23 @@ def tidy_text(text: str) -> str:
         The text tidied up for use in the terminal rather than on the web.
     """
     return sub("<[^<]+?>", "", unescape(text.replace("<p>", "\n\n")))
+
+
+HREF: Final[Pattern[str]] = compile(r'href="([^"]+)"')
+"""Regular expression for finding links in some text."""
+
+
+##############################################################################
+def text_urls(text: str) -> list[str]:
+    """Find any links in the given text.
+
+    Args:
+        text: The text to look in.
+
+    Returns:
+        The list of links found in the text.
+    """
+    return HREF.findall(unescape(text))
 
 
 ### text.py ends here


### PR DESCRIPTION
Add a quick method of visiting links within comments, in a keyboard-first-friendly way.

I still intend to do full HTML-parsing and making the comments look better and have links be full-on links; but to start with I want a keyboard-first-friendly method of extracting and visiting links. This is that.