### PR TITLE
Add support for showing item numbers in the lists

### DIFF
--- a/oshit/app/data/config.py
+++ b/oshit/app/data/config.py
@@ -23,6 +23,9 @@ class Configuration:
     compact_mode: bool = True
     """Should the items display in compact mode?"""
 
+    item_numbers: bool = False
+    """Should we show numbers against items in the lists?"""
+
     maximum_concurrency: int = 50
     """The maximum number of connections to use when getting items."""
 

--- a/oshit/app/screens/main.py
+++ b/oshit/app/screens/main.py
@@ -32,6 +32,7 @@ class Main(Screen[None]):
     | <kbd>F1</kbd> | This help screen. |
     | <kbd>F2</kbd> | Toggle compact/relaxed display. |
     | <kbd>F3</kbd> | Toggle dark/light mode. |
+    | <kbd>F4</kbd> | Toggle numbers against items. |
     | <kbd>F12</kbd> | Quit the application. |
     | <kbd>t</kbd> | View the top stories. |
     | <kbd>n</kbd> | View the new stories. |
@@ -53,6 +54,7 @@ class Main(Screen[None]):
         Binding("f1", "help", "Help"),
         Binding("f2", "compact", "Compact/Relaxed"),
         Binding("f3", "toggle_dark"),
+        Binding("f4", "numbered"),
         Binding("f12", "quit", "Quit"),
         Binding("t", "go('top')"),
         Binding("n", "go('new')"),
@@ -110,6 +112,11 @@ class Main(Screen[None]):
         """Toggle the compact display."""
         news = self.query_one(HackerNews)
         news.compact = not news.compact
+
+    def action_numbered(self) -> None:
+        """Toggle the numbers display."""
+        news = self.query_one(HackerNews)
+        news.numbered = not news.numbered
 
     @on(ShowUser)
     def show_user(self, event: ShowUser) -> None:

--- a/oshit/app/widgets/hacker_news.py
+++ b/oshit/app/widgets/hacker_news.py
@@ -27,9 +27,14 @@ class HackerNews(TabbedContent):
     compact: var[bool] = var(True)
     """Should we use a compact or relaxed display?"""
 
+    numbered: var[bool] = var(False)
+    """Should we show numbers against the items in the lists?"""
+
     def on_mount(self) -> None:
         """Configure the widget once the DOM is ready."""
-        self.compact = load_configuration().compact_mode
+        config = load_configuration()
+        self.compact = config.compact_mode
+        self.numbered = config.item_numbers
 
     @property
     def active_items(self) -> Items[Article]:
@@ -82,6 +87,14 @@ class HackerNews(TabbedContent):
             pane.compact = self.compact
         configuration = load_configuration()
         configuration.compact_mode = self.compact
+        save_configuration(configuration)
+
+    def _watch_numbered(self) -> None:
+        """React to the numbers setting value being changed."""
+        for pane in self.query(Items).results():
+            pane.numbered = self.numbered
+        configuration = load_configuration()
+        configuration.item_numbers = self.numbered
         save_configuration(configuration)
 
 


### PR DESCRIPTION
In support of satisfying #11. For the moment this is a keyboard toggle, and I think I might keep it like that. The state is written to the config file so it's persistent.