### PR TITLE
Tidy up the header

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # OSHit ChangeLog
 
+## WiP
+
+**Released: WiP**
+
+- Simplified the header bar, disabling Textual's mouse toggle of the height,
+  and removing the "icon" in the top left corner.
+
 ## v0.5.0
 
 **Released: 2024-01-17**

--- a/oshit/app/screens/main.py
+++ b/oshit/app/screens/main.py
@@ -50,6 +50,10 @@ class Main(Screen[None]):
     TabbedContent, LoadingIndicator {
         background: $panel;
     }
+
+    Header.-tall {
+        height: 1;
+    }
     """
 
     TITLE = f"Orange Site Hit v{__version__}"

--- a/oshit/app/screens/main.py
+++ b/oshit/app/screens/main.py
@@ -51,8 +51,14 @@ class Main(Screen[None]):
         background: $panel;
     }
 
-    Header.-tall {
-        height: 1;
+    Header {
+        HeaderIcon {
+            visibility: hidden;
+        }
+
+        &.-tall {
+            height: 1;
+        }
     }
     """
 


### PR DESCRIPTION
Tidies up the Textual `Header` widget so it's a better match for the application; removing the "icon" which does nothing here, and also removing the click to toggle the height, which does nothing useful.

Thanks to @mihaitodor for the prompt about the header in #13.