### PR TITLE
Add the ability to turn off the updating data age display

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # OSHit ChangeLog
 
+## WiP
+
+**Released: WiP**
+
+- Added the option to turn off the title-bar-based updating display of the
+  age of the items.
+
 ## v0.6.0
 
 **Released: 2024-01-23**

--- a/oshit/app/data/config.py
+++ b/oshit/app/data/config.py
@@ -26,6 +26,9 @@ class Configuration:
     item_numbers: bool = False
     """Should we show numbers against items in the lists?"""
 
+    show_data_age: bool = True
+    """Should we show the age of the data in the lists?"""
+
     maximum_concurrency: int = 50
     """The maximum number of connections to use when getting items."""
 

--- a/oshit/app/widgets/hacker_news.py
+++ b/oshit/app/widgets/hacker_news.py
@@ -30,11 +30,15 @@ class HackerNews(TabbedContent):
     numbered: var[bool] = var(False)
     """Should we show numbers against the items in the lists?"""
 
+    show_age: var[bool] = var(True)
+    """Should we show the age of the data in the lists?"""
+
     def on_mount(self) -> None:
         """Configure the widget once the DOM is ready."""
         config = load_configuration()
         self.compact = config.compact_mode
         self.numbered = config.item_numbers
+        self.show_age = config.show_data_age
 
     @property
     def active_items(self) -> Items[Article]:
@@ -95,6 +99,14 @@ class HackerNews(TabbedContent):
             pane.numbered = self.numbered
         configuration = load_configuration()
         configuration.item_numbers = self.numbered
+        save_configuration(configuration)
+
+    def _watch_show_age(self) -> None:
+        """React to the age showing setting being changed."""
+        for pane in self.query(Items).results():
+            pane.show_age = self.show_age
+        configuration = load_configuration()
+        configuration.show_data_age = self.show_age
         save_configuration(configuration)
 
 


### PR DESCRIPTION
Working off a request/suggestion in #13, this adds a toggle to turn off the display of the age of the items in the list. I did think about keeping it but allowing changing the frequency with which it updates, but the more I thought about it the more I got to thinking that with less frequency it becomes less useful anyway.

So here this makes it either pretty frequent, or who cares just let me browse.

This also improves the way that the title gets updated, removing the sneaky knowledge the `Items` widget has about the screen, instead moving to an approach that is purely message-based (in terms of requesting/causing a refresh).