### PR TITLE
Fix not being able to left/right during a reload

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 - Added the option to turn off the title-bar-based updating display of the
   age of the items.
+- Fixed not being able to change tabs with left/right during a reload.
 
 ## v0.6.0
 

--- a/oshit/app/widgets/hacker_news.py
+++ b/oshit/app/widgets/hacker_news.py
@@ -73,6 +73,7 @@ class HackerNews(TabbedContent):
             self.query_one(Tabs).action_next_tab()
 
     @on(TabbedContent.TabActivated)
+    @on(Items.Loading)
     def _settle_focus(self) -> None:
         """Settle the focus in the best place possible when a tab is activated."""
         if self.active_items.loaded:


### PR DESCRIPTION
When doing a reload of a tab the left/right appeared to not respond (really it was just down to where focus was settling). This fixes that; now you can navigate away from a reloading list just as you can navigate away from a freshly-loading list.