### PR TITLE
By default, load as-yet-unread tabs in the background

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # OSHit ChangeLog
 
+## WiP
+
+**Released: WiP**
+
+- Once the first viewed tab has loaded, other tabs will start to load in the
+  background (one after the other) as the user reads the first.
+- Added a config option to turn off the above.
+
 ## 0.10.0
 
 **Released: 2024-02-28**

--- a/oshit/app/data/config.py
+++ b/oshit/app/data/config.py
@@ -53,6 +53,9 @@ class Configuration:
     maximum_jobs: int = 200
     """The maximum number of jobs to show."""
 
+    background_load_tabs: bool = True
+    """Should the content of the tabs try and load in the background?"""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/oshit/app/widgets/items.py
+++ b/oshit/app/widgets/items.py
@@ -261,6 +261,17 @@ class Items(Generic[ArticleType], TabPane):
         display.loading = False
         self.post_message(self.Loaded())
 
+    def maybe_load(self) -> bool:
+        """Start loading the items if they're not loaded and aren't currently loading.
+
+        Returns:
+            `True` if it was decided to load the items, `False` if not.
+        """
+        if not self.loaded and not self.query_one(OptionList).loading:
+            self._load()
+            return True
+        return False
+
     @property
     def items(self) -> list[ArticleType]:
         """The items."""


### PR DESCRIPTION
The idea here is that, once the first tab is loaded and the user is reading the headlines, etc, the next as-yet-unloaded tab starts to load its stories in the background; when it has finished the next is asked to load, and so on.

In other words, by the time you've finished looking over "Top", all the other tabs should already be loaded and ready, making the whole thing feel faster.

Set this as an option in the application configuration so it can be turned off.