### PR TITLE
Don't create coroutines before they're needed when loading items

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
 - Once the first viewed tab has loaded, other tabs will start to load in the
   background (one after the other) as the user reads the first.
 - Added a config option to turn off the above.
+- Fixed a non-awaited-coroutine warning that could happen when quitting
+  while loading items. ([#26](https://github.com/davep/oshit/issues/26))
 
 ## 0.10.0
 

--- a/oshit/hn/client.py
+++ b/oshit/hn/client.py
@@ -155,13 +155,19 @@ class HN:
         """
         concurrency_limit = Semaphore(self._max_concurrency)
 
-        async def limited(coroutine: Awaitable[ItemType]) -> ItemType:
-            async with concurrency_limit:
-                return await coroutine
+        async def item(item_id: int) -> ItemType:
+            """Get an item, with a limit on concurrent requests.
 
-        return await gather(
-            *[limited(self.item(item_type, item_id)) for item_id in item_ids]
-        )
+            Args:
+                item_id: The ID of the item to get.
+
+            Returns:
+                The item.
+            """
+            async with concurrency_limit:
+                return await self.item(item_type, item_id)
+
+        return await gather(*[item(item_id) for item_id in item_ids])
 
     async def _id_list(self, list_type: str, max_count: int | None = None) -> list[int]:
         """Get a given ID list.


### PR DESCRIPTION
Fixes #26