### PR TITLE
Fix crash with `null` story data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        language_version: '3.10'
+        language_version: '3.12'
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.12

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # OSHit ChangeLog
 
+## v0.12.3
+
+**Released: 2024-07-24**
+
+- Fixed a crash when the HackerNews API returns `null` for an otherwise
+  valid and available story.
+
 ## v0.12.2
 
 **Released: 2024-06-23**

--- a/oshit/__init__.py
+++ b/oshit/__init__.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright 2024, Dave Pearson"
 __credits__ = ["Dave Pearson"]
 __maintainer__ = "Dave Pearson"
 __email__ = "davep@davep.org"
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 __licence__ = "GPLv3+"
 
 ##############################################################################

--- a/oshit/app/widgets/items.py
+++ b/oshit/app/widgets/items.py
@@ -229,6 +229,7 @@ class Items(Generic[ArticleType], TabPane):
             [
                 HackerNewsArticle(item, self.compact, number if self.numbered else None)
                 for number, item in enumerate(self._items)
+                if item.looks_valid
             ]
         )
         display.highlighted = remember

--- a/oshit/hn/client.py
+++ b/oshit/hn/client.py
@@ -135,7 +135,12 @@ class HN:
         Returns:
             The item.
         """
-        if isinstance(item := Loader.load(await self._raw_item(item_id)), item_type):
+        # If we can get the item but it comes back with no data at all...
+        if not (data := await self._raw_item(item_id)):
+            # ...as https://hacker-news.firebaseio.com/v0/item/41050801.json
+            # does for some reason, just make an empty version of the item.
+            return item_type()
+        if isinstance(item := Loader.load(data), item_type):
             return item
         raise ValueError(
             f"The item of ID '{item_id}' is of type '{item.item_type}', not {item_type.__name__}"

--- a/oshit/hn/item/base.py
+++ b/oshit/hn/item/base.py
@@ -71,6 +71,11 @@ class Item:
         """Does the item have any text?"""
         return bool(self.text.strip())
 
+    @property
+    def looks_valid(self) -> bool:
+        """Does the item look valid?"""
+        return bool(self.item_id) and bool(self.item_type)
+
     def __contains__(self, search_for: str) -> bool:
         return (
             search_for.casefold() in self.by.casefold()


### PR DESCRIPTION
https://news.ycombinator.com/item?id=41050801 is a job that I can see on HackerNews. Via https://hacker-news.firebaseio.com/v0/item/41050801.json (in other words via their API) though it comes back as pure `null`. This change stops this causing a problem.