### PR TITLE
Fix search shortcut key not working

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # OSHit ChangeLog
 
+## v0.12.4
+
+**Released: 2024-08-02**
+
+- Fixed a crash when the HackerNews API returns `null` for an otherwise
+  valid and available story.
+
 ## v0.12.3
 
 **Released: 2024-07-24**

--- a/oshit/__init__.py
+++ b/oshit/__init__.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright 2024, Dave Pearson"
 __credits__ = ["Dave Pearson"]
 __maintainer__ = "Dave Pearson"
 __email__ = "davep@davep.org"
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 __licence__ = "GPLv3+"
 
 ##############################################################################

--- a/oshit/app/screens/main.py
+++ b/oshit/app/screens/main.py
@@ -77,6 +77,7 @@ class Main(Screen[None]):
         Binding("a", "go('ask')"),
         Binding("s", "go('show')"),
         Binding("j", "go('jobs')"),
+        Binding("r", "go('search')"),
         Binding("/", "local_search"),
     ]
 
@@ -156,7 +157,12 @@ class Main(Screen[None]):
         Args:
             items: The name of the list of items to go to.
         """
-        self.query_one(HackerNews).active = items
+        before = self.query_one(HackerNews).active
+        try:
+            self.query_one(HackerNews).active = items
+        except ValueError:
+            self.query_one(HackerNews).active = before
+            return
         self.query_one(HackerNews).focus_active_pane()
 
     def action_compact(self) -> None:


### PR DESCRIPTION
When I first introduced the local search facility it looks like I added support for *telling* which shortcut key will jump to the results tab, but I didn't actually implement support for this.

This PR adds that support.
