### PR TITLE
Fix a crash due to an article lacking documented properties

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # OSHit ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Fix a crash due to an article missing a `score` and `title`.
+
 ## v0.12.4
 
 **Released: 2024-08-02**

--- a/oshit/hn/item/article.py
+++ b/oshit/hn/item/article.py
@@ -38,8 +38,8 @@ class Article(ParentItem):
             Self
         """
         self.descendants = data.get("descendants", 0)
-        self.score = data["score"]
-        self.title = data["title"]
+        self.score = data.get("score", 0)
+        self.title = data.get("title", "")
         return super().populate_with(data)
 
     def __contains__(self, search_for: str) -> bool:


### PR DESCRIPTION
An article has turned up minus a `score` or `title` property, despite the API being documented as these being properties of articles. So let's default to zero and an empty string.